### PR TITLE
Fix size string

### DIFF
--- a/core/src/main/java/org/owasp/passfault/TimeToCrack.java
+++ b/core/src/main/java/org/owasp/passfault/TimeToCrack.java
@@ -165,7 +165,7 @@ public enum TimeToCrack {
       rounded = rounded / 1000;
     }
     StringBuilder builder = new StringBuilder();
-    builder.append((int) rounded);
+    builder.append( Math.round(rounded) );
     String types[] = new String[]{
       "hundred",
       "thousand",

--- a/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
+++ b/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
@@ -37,7 +37,8 @@ public class RepeatingPatternFinder {
       boolean foundDuplicate = false;
       for (int j = i - 1; j >= 0; j--) {
         PasswordPattern toCompare = path.get(j);
-        if (toCompare.getName().equals(pass.getName())
+        if (!toCompare.getName().equals(RandomPattern.RANDOM_PATTERN)
+            && toCompare.getName().equals(pass.getName())
             && toCompare.getMatchString().equals(pass.getMatchString())) {
           //repeated-duplicate pattern instance
           foundDuplicate = true;

--- a/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
+++ b/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
@@ -37,8 +37,7 @@ public class RepeatingPatternFinder {
       boolean foundDuplicate = false;
       for (int j = i - 1; j >= 0; j--) {
         PasswordPattern toCompare = path.get(j);
-        if (!toCompare.getName().equals(RandomPattern.RANDOM_PATTERN)
-            && toCompare.getName().equals(pass.getName())
+        if (toCompare.getName().equals(pass.getName())
             && toCompare.getMatchString().equals(pass.getMatchString())) {
           //repeated-duplicate pattern instance
           foundDuplicate = true;


### PR DESCRIPTION
 getRoundedSizeString() now more accurate

Now rounds to nearest integer when computing size string instead of rounding
down to nearest integer. Before 1.9 thousand would be displayed as '1 thousand'.
Now it displays as '2 thousand'.

This is more accurate without being overly accurate (1.946784654 thousand). I
believe avoiding 'over-accuracy' was the original intent

I'm not really sure on the exact protocol for requesting multiple separate changes at the same time. I decided to put all of the changes I made into different requests, but I had to fight with git a little bit. I hope this is ok. I'm new at this :)