### PR TITLE
Rand patterns

### DIFF
--- a/core/src/main/java/org/owasp/passfault/TimeToCrack.java
+++ b/core/src/main/java/org/owasp/passfault/TimeToCrack.java
@@ -165,7 +165,7 @@ public enum TimeToCrack {
       rounded = rounded / 1000;
     }
     StringBuilder builder = new StringBuilder();
-    builder.append((int) rounded);
+    builder.append( Math.round(rounded) );
     String types[] = new String[]{
       "hundred",
       "thousand",

--- a/core/src/main/java/org/owasp/passfault/TimeToCrack.java
+++ b/core/src/main/java/org/owasp/passfault/TimeToCrack.java
@@ -165,7 +165,7 @@ public enum TimeToCrack {
       rounded = rounded / 1000;
     }
     StringBuilder builder = new StringBuilder();
-    builder.append( Math.round(rounded) );
+    builder.append((int) rounded);
     String types[] = new String[]{
       "hundred",
       "thousand",

--- a/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
+++ b/core/src/main/java/org/owasp/passfault/finders/RepeatingPatternFinder.java
@@ -37,8 +37,7 @@ public class RepeatingPatternFinder {
       boolean foundDuplicate = false;
       for (int j = i - 1; j >= 0; j--) {
         PasswordPattern toCompare = path.get(j);
-        if (!toCompare.getName().equals(RandomPattern.RANDOM_PATTERN)
-            && toCompare.getName().equals(pass.getName())
+        if (toCompare.getName().equals(pass.getName())
             && toCompare.getMatchString().equals(pass.getMatchString())) {
           //repeated-duplicate pattern instance
           foundDuplicate = true;


### PR DESCRIPTION
 Now recognizes repeated random patterns

Previously the password 76441aaa76441 was not found to have a repeated pattern
in it. This is in contrast to say, something like apple2867apple where the
duplication of apple is recognized.

Before:
'76441' matches the pattern 'Random Characters with:Numbers'
	100 thousand passwords in the pattern
	49.74 percent of password strength
'aaa' matches the pattern 'Keyboard repeated character'
	1 thousand passwords in the pattern
	0.51 percent of password strength
'76441' matches the pattern 'Random Characters with:Numbers'
	100 thousand passwords in the pattern
	49.74 percent of password strength
Total passwords in all patterns: 10 trillion

After:
'76441' matches the pattern 'Random Characters with:Numbers'
    100 thousand passwords in the pattern
    98.98 percent of password strength
'aaa' matches the pattern 'Keyboard repeated character'
    1 thousand passwords in the pattern
    1.02 percent of password strength
'76441' matches the pattern 'Duplication of an earlier pattern: RANDOM_CHARACTERS'
    1 hundred passwords in the pattern
    0.00 percent of password strength
Total passwords in all finders: 103 million

I'm trying to keep the individual fixes in seperate requests but this is my first time on github, Please be kind. Let me know how how I'm doing