### PR TITLE
Updated appengine version to fix issues with deprecated plugin.

### DIFF
--- a/appEngine/build.gradle
+++ b/appEngine/build.gradle
@@ -8,16 +8,16 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.appengine:gradle-appengine-plugin:1.9.4'
+        classpath 'com.google.appengine:gradle-appengine-plugin:1.9.23'
     }
 }
 
 dependencies {
-  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.4'
+  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.23'
   compile 'javax.servlet:servlet-api:2.5'
   compile project(':core')
   compile project(':jsonService')
-  appengineSdk 'com.google.appengine:appengine-java-sdk:1.9.4'
+  appengineSdk 'com.google.appengine:appengine-java-sdk:1.9.23'
 }
 
 appengine {


### PR DESCRIPTION
Building the project was failing due to a conflict with the appengine dependency.
The error that was given was:

> c:\cygwin64\home\travis.almey\passfault\jsonService>gradle build jettyRunWar
> 
> FAILURE: Build failed with an exception.
> 
> * Where:
> Build file 'C:\cygwin64\home\travis.almey\passfault\appEngine\build.gradle' line: 2
> 
> * What went wrong:
> A problem occurred evaluating project ':appEngine'.
> \> Failed to apply plugin [id 'appengine']
>    \> No such property: model for class: org.gradle.plugins.ide.eclipse.EclipsePlugin
> 
> * Try:
> Run with --stacktrace option to get the stack trace. Run with --info or --debug
> option to get more log output.
> 
> BUILD FAILED
> 
> Total time: 4.567 secs

With this change the project builds correctly.
This change might also address issue #50 